### PR TITLE
General improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ After simply add the name of this resource to your `server.cfg` resource section
 Then simply clone this repository into your main server resources folder.
 
 ```
-cd resources
-git clone https://github.com/LeonMrBonnie/altv-os-i10n i10n
+git clone https://github.com/LeonMrBonnie/altv-os-i10n resources/i10n
 ```
 
 Ensure your `package.json` includes this property:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This resource is very simple.
 
 After simply add the name of this resource to your `server.cfg` resource section.
 
-`altv-os-i18n`
+`altv-os-i10n`
 
 Then simply clone this repository into your main server resources folder.
 
@@ -46,7 +46,7 @@ To use the resource it has to be added to the `deps` array in the `resource.cfg`
 Afterwards you can just import the resource by using:
 
 ```js
-import * as i18n from "altv-os-i10n";
+import * as i10n from "altv-os-i10n";
 ```
 
 And you can then use the exported functions.

--- a/README.md
+++ b/README.md
@@ -65,13 +65,16 @@ You can edit the translations by just editing the corresponding `.json` file.
 
 # Available functions
 
-### _ (alias translate)
+### translate
 
 Translates the given translation key to the given language.
 If the language or translation was not found, it will return the translation key.
 Otherwise it will return the translated version of the translation key.
 
 ```ts
+function translate(lang: string, key: string): string;
+
+// As of commit 74f7bb9, the new - preferred version of using `translate` can be accessed by directly importing the _ function.
 function _(lang: string, key: string): string;
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Then simply clone this repository into your main server resources folder.
 
 ```
 cd resources
-git clone https://github.com/LeonMrBonnie/altv-os-i10n
+git clone https://github.com/LeonMrBonnie/altv-os-i10n i10n
 ```
 
 Ensure your `package.json` includes this property:
@@ -46,10 +46,14 @@ To use the resource it has to be added to the `deps` array in the `resource.cfg`
 Afterwards you can just import the resource by using:
 
 ```js
-import * as i10n from "altv-os-i10n";
+import * as i10n from "i10n";
 ```
 
-And you can then use the exported functions.
+And you can then use the exported functions-- though it would be preferable if you directly imported what is required:
+
+```js
+import { _ } from "i10n";
+```
 
 # Adding a new language or updating an existing one
 
@@ -61,14 +65,14 @@ You can edit the translations by just editing the corresponding `.json` file.
 
 # Available functions
 
-### translate
+### _ (alias translate)
 
 Translates the given translation key to the given language.
 If the language or translation was not found, it will return the translation key.
 Otherwise it will return the translated version of the translation key.
 
 ```ts
-function translate(lang: string, key: string): string;
+function _(lang: string, key: string): string;
 ```
 
 ### getLanguages

--- a/server.js
+++ b/server.js
@@ -28,7 +28,7 @@ async function loadLanguages() {
  * @param {string} lang Language name
  * @param {string} key Translation key
  */
-export function translate(lang, key) {
+export function _(lang, key) {
     if (!languages[lang]) return key;
     let translated = languages[lang][key];
     if (!translated) return key;

--- a/server.js
+++ b/server.js
@@ -36,6 +36,15 @@ export function _(lang, key) {
 }
 
 /**
+ * Translates the specified translation key with the specified language
+ * @param {string} lang Language name
+ * @param {string} key Translation key
+ */
+export function translate(lang, key) {
+    return _(lang, key);
+}
+
+/**
  * Returns all available languages
  */
 export function getLanguages() {


### PR DESCRIPTION
* Things are now more unified across the board.
  * i18n in the README.md was replaced with i10n.
  * The imports for the module were renamed. You can now import this module by using `i10n`, rather than having to type out `altv-os-i10n` each time.
  * The `translate` function was replaced by `_`, but to maintain backwards compatibility, `translate` was made an alias of `_`.